### PR TITLE
FIX: downgrade target SDK to 27 to fix SELinux policy on Android P.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,8 @@ android {
     defaultConfig {
         applicationId "bin.xposed.Unblock163MusicClient"
         minSdkVersion 16
-        targetSdkVersion 28
+        // target Android P 之后，在安装过程中会对 APP 文件目录实行严格的 SELinux 限制，即使 makeWorkdReadable，其他 APP 也无法读取插件的任何配置文件
+        targetSdkVersion 27
         versionCode 28
         versionName = "0.0.${versionCode}"
         archivesBaseName = "${applicationId}-${versionName}"


### PR DESCRIPTION
修复 Android 9.0 以上插件不生效的问题。

如果插件 target SDK 在 28以上，那么在安装过程中会对 插件 APP 目录实行严格的 SELinux 限制；即使插件自己把目录和文件权限设置为 777，其他 APP 对插件目录的读取过程也会被 SELinux 阻止。

虽然在可以刷机的情况下，可以通过 supolicy/magiskpolicy 强制修改 SELinux 策略，使得这条 SELinux Policy 规则失效；但是这么做会降低一定的安全性。

如果使用的免ROOT版，那么就对这条规则无能为力。只要插件 target 28，被 插件 hook 的进程无法读取到插件的配置，使得插件失效。

现在临时降级 target SDK 可以解决这个问题；后续如果Google 强制实施target sdk 规则可以通过网络配置，跨进程通信等手段解决。